### PR TITLE
Add reset code to Wolfram link

### DIFF
--- a/bin/gxpr
+++ b/bin/gxpr
@@ -40,7 +40,7 @@ res=$(
 # if we don't have a result, try wolfram alpha
 test -z "$res" && {
     echo "google doesn't know" "$@" 1>&2
-    echo "⌘ click: \033[4m$WOLFRAM?i=$EXPR"
+    echo "⌘ click: \033[4m$WOLFRAM?i=$EXPR\033[0m"
     exit 1
 }
 


### PR DESCRIPTION
I noticed there's no reset code at the end of the Wolfram link. I'm no pro when it comes to color codes, but I think this is all that's needed.
