### PR TITLE
Escape forward slashes in branch names

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -21,6 +21,9 @@ branch=${1:-"$(git symbolic-ref HEAD | sed 's@refs/heads/@@')"}
 
 # check that the branch exists in the origin remote first
 if git rev-parse "refs/remotes/origin/$branch" 1>/dev/null 2>&1; then
+    # escape forward slashes
+    branch=${branch//\//\%2f}
+
     exec open "https://github.com/$repo_with_owner/pull/$branch"
 else
     echo "error: branch '$branch' does not exist on the origin remote." 1>&2


### PR DESCRIPTION
I saw your tweet today and loved the `git-pr` helper. However, we use forward slashes in our branch names and I was getting a 404 on github.

This patch fixes that by escaping the forward slashes in the branch name with the URL escape code `%2f`
