### PR TITLE
Use zsh's $commands array

### DIFF
--- a/color/grc.symlink/grc.zsh
+++ b/color/grc.symlink/grc.zsh
@@ -1,4 +1,4 @@
 # aliases for GRC from homebrew
-if $(grc &>/dev/null) && $(brew &>/dev/null); then
+if (( $+commands[grc] )) && (( $+commands[brew] )); then
   source `brew --prefix grc`/etc/grc.bashrc
 fi

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -144,8 +144,7 @@ function git_time_since_commit() {
 # command line. I filter it to only count those tagged as "+next", so it's more
 # of a motivation to clear out the list.
 prompt_todo_count(){
-  if $(which todo.sh &> /dev/null)
-  then
+  if (( $+commands[todo.sh] )); then
     num=$(echo $(todo.sh ls $1 | wc -l))
     let todos=num-2
     echo "$todos"


### PR DESCRIPTION
Instead of 

```
if $(which program-name &> /dev/null)
  echo "it is available"
fi
```

you should / can use zsh's $commands array

```
if (( $+commands[program-name] )); then
  echo "it is available"
fi
```
