### PR TITLE
mx: check existing sessons exactly

### DIFF
--- a/bin/mx
+++ b/bin/mx
@@ -53,7 +53,7 @@ _safe_window() {
   fi
 }
 
-if ! (tmux has-session -t "$SESSION" >/dev/null 2>&1); then
+if ! (tmux list-sessions | cut -d':' -f1 | grep -q ^"$SESSION"\$); then
   if [ -d "$PROJECTS"/"$SESSION" ]; then
     cd "$PROJECTS"/"$SESSION"
   fi


### PR DESCRIPTION
From the tmux man page:

>  When looking for the session name, tmux initially searches for an
>  exact match; if none is found, the session names are checked for any
>  for which target-session is a prefix or for which it matches as an
>  fnmatch(3) pattern.

This means that the 'tmux has-session' command will return true even if an exact match wasn't found. This is often useful, but not in this case since an exact match is wanted.
