### PR TITLE
Also show the private keyword

### DIFF
--- a/bin/lsrb
+++ b/bin/lsrb
@@ -12,6 +12,6 @@ set -e
 # run over files and grep out interesting bits
 for f in "$@"
 do echo "$f:"
-   grep -e '^[ 	]*\(class\|module\|def\|alias\|alias_method\) ' "$f" |
-   sed 's/^/  /'
+    grep -e '^[  ]*\(class\|module\|def\|alias\|alias_method\|private\)\(\s\|$\)' "$f" |
+    sed 's/^/  /'
 done


### PR DESCRIPTION
Showing the private keyword allows you to know where the public API of a class ends.
